### PR TITLE
Added parameter to specify dependency on python-simplejson for SL5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,10 +44,10 @@ rpm: prepare-spec
 		$(rpmbuild_dir)/SPECS \
 		$(rpmbuild_dir)/SRPMS
 	cp $(source_dir)/$(name).tar.gz $(rpmbuild_dir)/SOURCES/$(name)-$(rpm_version).tar.gz
-ifndef sl5extra
+ifndef python_json_package
 	rpmbuild --nodeps -v -ba $(spec) --define "_topdir $(rpmbuild_dir)" --define "dist $(dist)"
 else
-	rpmbuild --nodeps -v -ba $(spec) --define "_topdir $(rpmbuild_dir)" --define "dist $(dist)" --define "sl5extra $(sl5extra)"
+	rpmbuild --nodeps -v -ba $(spec) --define "_topdir $(rpmbuild_dir)" --define "dist $(dist)" --define "python_json_package $(python_json_package)"
 endif
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,11 @@ rpm: prepare-spec
 		$(rpmbuild_dir)/SPECS \
 		$(rpmbuild_dir)/SRPMS
 	cp $(source_dir)/$(name).tar.gz $(rpmbuild_dir)/SOURCES/$(name)-$(rpm_version).tar.gz
+ifndef sl5extra
 	rpmbuild --nodeps -v -ba $(spec) --define "_topdir $(rpmbuild_dir)" --define "dist $(dist)"
+else
+	rpmbuild --nodeps -v -ba $(spec) --define "_topdir $(rpmbuild_dir)" --define "dist $(dist)" --define "sl5extra $(sl5extra)"
+endif
 
 clean:
 	rm -rf $(source_dir) $(rpmbuild_dir) $(spec)

--- a/storm-dynamic-info-provider.spec.in
+++ b/storm-dynamic-info-provider.spec.in
@@ -26,6 +26,11 @@ Requires: python-ldap
 Requires: python-argparse
 Requires: bdii
 
+%if %{?sl5extra:1}%{!?sl5extra:0} 
+%define extra %{sl5extra}
+Requires: %{extra}
+%endif
+
 %description
 This is the installation bundle for the StoRM info provider component.
 

--- a/storm-dynamic-info-provider.spec.in
+++ b/storm-dynamic-info-provider.spec.in
@@ -26,9 +26,8 @@ Requires: python-ldap
 Requires: python-argparse
 Requires: bdii
 
-%if %{?sl5extra:1}%{!?sl5extra:0} 
-%define extra %{sl5extra}
-Requires: %{extra}
+%if %{?python_json_package:1}%{!?python_json_package:0} 
+Requires: %{python_json_package}
 %endif
 
 %description


### PR DESCRIPTION
Example of make:
make tag=develop dist=.el5 sl5extra=python-simplejson rpm (on SL5)
make tag=develop rpm (on SL6)
